### PR TITLE
fix double-despawn of observers

### DIFF
--- a/crates/beet_flow/macros/src/action/derive_action.rs
+++ b/crates/beet_flow/macros/src/action/derive_action.rs
@@ -32,7 +32,7 @@ fn impl_component_hooks(
 	_input: &DeriveInput,
 	attributes: &ActionAttributes,
 ) -> syn::Result<Option<TokenStream>> {
-	if attributes.observers.len() == 0 {
+	if attributes.observers.is_empty() {
 		return Ok(None);
 	}
 
@@ -44,10 +44,8 @@ fn impl_component_hooks(
 				ActionObserversBuilder::new::<Self>()
 				.add_observers((#observers))
 				.build(world.commands(), entity);
-			})
-		.on_remove(|mut world, entity, _|{
-				ActionObserversBuilder::cleanup::<Self>(&mut world,entity);
 			});
+		// bevy automatically despawns observers when the entities they are watching are despawned
 	}))
 }
 

--- a/crates/beet_flow/src/observers/action_observers_builder.rs
+++ b/crates/beet_flow/src/observers/action_observers_builder.rs
@@ -23,6 +23,9 @@ impl<T> Default for ActionObserversBuilder<T, (), ()> {
 
 impl ActionObserversBuilder<(), (), ()> {
 	pub fn new<T>() -> ActionObserversBuilder<T, (), ()> { Default::default() }
+	/// Bevy guarantees that if all entities watched by a given Observer are despawned,
+	/// the Observer entity will also be despawned.
+	/// This function should only be used in situations other than the above.
 	pub fn cleanup<'w, T: 'static + Send + Sync>(
 		world: &mut DeferredWorld<'w>,
 		entity: Entity,


### PR DESCRIPTION
Remove code that despawns observers, since bevy does it anyway.

This was that cause of some warnings like:
```
Could not despawn entity 236v1#4294967532 because it doesn't exist in this World. See: https://bevyengine.org/learn/errors/b0003
```

> If all entities watched by a given [Observer](https://docs.rs/bevy/latest/bevy/prelude/struct.Observer.html) are despawned, the [Observer](https://docs.rs/bevy/latest/bevy/prelude/struct.Observer.html) entity will also be despawned. This protects against observer “garbage” building up over time.

https://docs.rs/bevy/latest/bevy/prelude/struct.Observer.html

