### PR TITLE
Fix despawning observers

### DIFF
--- a/crates/beet_flow/macros/src/action/derive_action.rs
+++ b/crates/beet_flow/macros/src/action/derive_action.rs
@@ -39,17 +39,17 @@ fn impl_component_hooks(
 	let observers = attributes.observers.collect_comma_punct();
 
 	Ok(Some(quote! {
-		app.world_mut().register_component_hooks::<Self>()
+		app.world_mut()
+		.register_component_hooks::<Self>()
 		.on_add(|mut world, entity, _| {
-				ActionObserversBuilder::new::<Self>()
-				.add_observers((#observers))
-				.build(world.commands(), entity);
-			})
-			.on_remove(|mut world, entity, _|{
-				ActionObserversBuilder::cleanup::<Self>(&mut world,entity)
-			});
+			ActionObserversBuilder::new::<Self>()
+			.add_observers((#observers))
+			.build(world.commands(), entity);
+		});
+		app.add_observer(ActionObserversBuilder::cleanup_trigger::<Self>);
 	}))
 }
+
 
 
 fn impl_action_builder(

--- a/crates/beet_flow/src/actions/misc/trigger_in_duration.rs
+++ b/crates/beet_flow/src/actions/misc/trigger_in_duration.rs
@@ -45,7 +45,9 @@ pub fn trigger_in_duration<T: GenericActionEvent>(
 ) {
 	for (entity, timer, action) in query.iter_mut() {
 		if timer.last_started.elapsed() >= action.duration {
-			commands.entity(entity).trigger(action.value.clone());
+			if let Some(mut e) = commands.get_entity(entity) {
+				e.trigger(action.value.clone());
+			}
 		}
 	}
 }

--- a/crates/beet_flow/src/actions/on_trigger/on_trigger_action.rs
+++ b/crates/beet_flow/src/actions/on_trigger/on_trigger_action.rs
@@ -91,9 +91,8 @@ impl<Handler: OnTriggerHandler> OnTrigger<Handler> {
 
 impl<Handler: OnTriggerHandler> ActionBuilder for OnTrigger<Handler> {
 	fn build(app: &mut App, _config: &BeetConfig) {
-		app.world_mut()
-			.register_component_hooks::<Self>()
-			.on_add(|mut world, action_entity, _| {
+		app.world_mut().register_component_hooks::<Self>().on_add(
+			|mut world, action_entity, _| {
 				let action = world.get::<Self>(action_entity).unwrap();
 				// use closure to capture the action entity
 				let mut observer = Observer::new(
@@ -128,10 +127,9 @@ impl<Handler: OnTriggerHandler> ActionBuilder for OnTrigger<Handler> {
 				commands
 					.entity(entity)
 					.insert(ActionObserverMap::<Self>::new(vec![entity]));
-			})
-			.on_remove(|mut world, entity, _| {
-				ActionObserversBuilder::cleanup::<Self>(&mut world, entity);
-			});
+			},
+		);
+		app.add_observer(ActionObserversBuilder::cleanup_trigger::<Self>);
 	}
 }
 
@@ -155,7 +153,7 @@ mod test {
 		expect(&*world).to_have_component::<Running>(entity);
 	}
 	#[test]
-	fn other_sources()  {
+	fn other_sources() {
 		let mut app = App::new();
 		app.add_plugins(ActionPlugin::<InsertOnRun<Running>>::default());
 		let world = app.world_mut();


### PR DESCRIPTION
Follow-up to PR #19 since the on_remove thing was readded

I get this error now when despawning entities that have an action component:

<code>
error[B0003]: src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.15.0/src/observer/entity_observer.rs:37:48: Could not despawn entity 3989v1#4294971285 because it doesn't exist in this World. See: https://bevyengine.org/learn/errors/b0003

</code>



## example
this is related to how bevy automatically despawns observer entities when a (non-global) observer has no alive entities left that it's watching.

bevy's observer code adds an `ObservedBy` component to entities, which tracks a list of observer entities that watch that entity.

this `ObservedBy` has an `on_remove` hook, which will attempt to despawn the same observer that the `ActionObserversBuilder::cleanup` fn does, but it doesn't use `try_despawn`:

https://github.com/bevyengine/bevy/blob/v0.15.0/crates/bevy_ecs/src/observer/entity_observer.rs#L37

and this generates the error message. the `ObservedBy` `on_remove` hook must be running after our action component's `on_remove`.

## possible solutions

1) submit patch to bevy to change that to `try_despawn` – but since what we're doing is a bit niche, having bevy complain in that situation is probably a useful debugging feature, so i'm not sure if it is the best option.

2) change our on_remove to be a global observer on `Trigger<OnRemove, MyActionComponent>`, and since triggers run after hooks, the `ObservedBy` code will have done the despawn, and our use of `try_despawn` will avoid the error message.

This PR implements option 2.

