### PR TITLE
refactor: `McpServer` now owns its repository

### DIFF
--- a/crates/beet_mcp/Cargo.toml
+++ b/crates/beet_mcp/Cargo.toml
@@ -17,10 +17,10 @@ openai = []
 [dependencies]
 #💡 utils
 tokio = { version = "1", features = [
-	"macros",
-	"rt-multi-thread",
-	"io-std",
-	"signal",
+    "macros",
+    "rt-multi-thread",
+    "io-std",
+    "signal",
 ] }
 sweet = { path = "../../ws_sweet/sweet", features = ["fs"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -35,12 +35,12 @@ extend = "1"
 #💡 mcp
 # rmcp = { path = "../../../rmcp/crates/rmcp", features = [
 rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
-	"client",
-	"__reqwest",
-	"transport-io",
-	"transport-sse-client",
-	"transport-sse-server",
-	"transport-child-process",
+    "client",
+    "__reqwest",
+    "transport-io",
+    "transport-sse-client",
+    "transport-sse-server",
+    "transport-child-process",
 ] }
 axum = { version = "0.8", features = ["macros"] }
 serde_json = "1"
@@ -51,7 +51,7 @@ rig-sqlite = { version = "0.1", features = [] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 sqlite-vec = "0.1"
 tokio-rusqlite = { version = "0.6", features = [
-	"bundled",
+    "bundled",
 ], default-features = false }
 
 

--- a/crates/beet_mcp/src/bin/index-all.rs
+++ b/crates/beet_mcp/src/bin/index-all.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
 	// std::fs::remove_dir_all(".cache/").ok();
 	init_tracing(tracing::Level::INFO);
 	let model = EmbedModel::from_env();
-	IndexRepository::new(model)
+	IndexRepository::new(model &KNOWN_SOURCES)
 		.try_index_all_known_crates(|(key, _)| {
 			// TODO clap args
 			matches!(
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
 				| ContentType::Examples
 				| ContentType::Guides
 				// the slowest one, indexes all source code, takes about 5 mins for bevy 0.16
-				// | ContentType::Internals 
+				// | ContentType::Internals
 			) && key.crate_meta.crate_version == "0.16.0"
 		})
 		.await?;

--- a/crates/beet_mcp/src/bin/index-all.rs
+++ b/crates/beet_mcp/src/bin/index-all.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
 	// std::fs::remove_dir_all(".cache/").ok();
 	init_tracing(tracing::Level::INFO);
 	let model = EmbedModel::from_env();
-	IndexRepository::new(model &KNOWN_SOURCES)
+	IndexRepository::new(model, &KNOWN_SOURCES)
 		.try_index_all_known_crates(|(key, _)| {
 			// TODO clap args
 			matches!(

--- a/crates/beet_mcp/src/bin/sse-server.rs
+++ b/crates/beet_mcp/src/bin/sse-server.rs
@@ -7,5 +7,10 @@ async fn main() -> Result<()> {
 	init_tracing(tracing::Level::DEBUG);
 	#[cfg(not(debug_assertions))]
 	init_tracing(tracing::Level::INFO);
-	McpServer::serve_sse(EmbedModel::from_env(), "127.0.0.1:8000").await
+	McpServer::serve_sse(
+		EmbedModel::from_env(),
+		"127.0.0.1:8000",
+		KNOWN_SOURCES.clone(),
+	)
+	.await
 }

--- a/crates/beet_mcp/src/crate_rag/content_source.rs
+++ b/crates/beet_mcp/src/crate_rag/content_source.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 use std::path::Path;
 use sweet::prelude::*;
 
-
 /*
 that also gets me thinking about the difference between the big expensive censored models and these local libre models, like in the 90s we got local 3d graphics which spawned the demo scene, what does that look like for ml
 */
@@ -71,7 +70,7 @@ impl std::fmt::Display for ContentSourceKey {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContentSource {
 	/// crate metadata
 	pub crate_meta: CrateMeta,
@@ -87,7 +86,6 @@ pub struct ContentSource {
 	/// strategy for splitting text into chunks
 	pub split_text: SplitText,
 }
-
 
 impl ContentSource {
 	pub fn local_repo_path(&self) -> AbsPathBuf {

--- a/crates/beet_mcp/src/crate_rag/known_sources.rs
+++ b/crates/beet_mcp/src/crate_rag/known_sources.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use anyhow::Result;
 use serde::Deserialize;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use sweet::prelude::GlobFilter;
@@ -10,9 +11,7 @@ pub struct KnownSources(HashMap<ContentSourceKey, ContentSource>);
 
 impl std::ops::Deref for KnownSources {
 	type Target = HashMap<ContentSourceKey, ContentSource>;
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+	fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 impl KnownSources {
@@ -160,7 +159,7 @@ struct SourceBuilder {
 	version: String,
 }
 
-static KNOWN_SOURCES: LazyLock<KnownSources> = LazyLock::new(|| {
+pub static KNOWN_SOURCES: LazyLock<KnownSources> = LazyLock::new(|| {
 	let mut map = HashMap::new();
 
 	// still working on a better way to do this.

--- a/crates/beet_mcp/src/main.rs
+++ b/crates/beet_mcp/src/main.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
 	init_tracing(tracing::Level::DEBUG);
 	#[cfg(not(debug_assertions))]
 	init_tracing(tracing::Level::INFO);
-	McpServer::new(EmbedModel::from_env())
+	McpServer::new(EmbedModel::from_env(), KNOWN_SOURCES.clone())
 		.await?
 		.serve_stdio()
 		.await

--- a/crates/beet_mcp/src/vector_db/split_text.rs
+++ b/crates/beet_mcp/src/vector_db/split_text.rs
@@ -1,13 +1,14 @@
 use crate::prelude::Document;
+use serde::Deserialize;
+use serde::Serialize;
 use std::ops::Range;
 use std::path::Path;
 use text_splitter::CodeSplitter;
 use text_splitter::MarkdownSplitter;
 use text_splitter::TextSplitter;
 
-
 /// Split text into chunks, using the extension to determine the approach
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SplitText {
 	/// Range of character count to use for chunking.
 	pub chunk_range: Range<usize>,
@@ -27,7 +28,9 @@ impl Default for SplitText {
 const DEFAULT_CHUNK_RANGE: Range<usize> = 1500..3000;
 
 impl SplitText {
-	pub fn new(chunk_range: Range<usize>) -> Self { Self { chunk_range } }
+	pub fn new(chunk_range: Range<usize>) -> Self {
+		Self { chunk_range }
+	}
 
 	pub fn split<'a>(
 		&self,
@@ -72,16 +75,10 @@ impl SplitText {
 	}
 }
 
-
-
-
-
-
 #[cfg(test)]
 mod test {
 	use super::*;
 	use std::path::Path;
-
 
 	#[test]
 	fn test_split_markdown() {
@@ -124,11 +121,11 @@ impl TestStruct {
     pub fn new(field1: String, field2: i32) -> Self {
         Self { field1, field2 }
     }
-    
+
     pub fn get_field1(&self) -> &str {
         &self.field1
     }
-    
+
     pub fn get_field2(&self) -> i32 {
         self.field2
     }
@@ -173,7 +170,6 @@ fn main() {
 	fn test_split_no_extension() {
 		let content = "This is content without any file extension. ".repeat(10);
 		let chunks = SplitText::default().split("test.xyz", &content);
-
 
 		assert!(!chunks.is_empty());
 		// Should fall back to default text splitting


### PR DESCRIPTION
## Objective
Provide the ability to ser/de a list of KnownSources

## Solution
- `KnownSources` is now a newtype struct
- Adjust `McpServer` and `IndexRepository` struct to take ownership or references of `KnownSources`

## Notes
Seems like my `rust-analyzer`/`cargo-fmt` is misinterpreting the `rustfmt.toml` file at the root. I attempted to undo some of my changes by running `cargo fmt --all`, but that appears to 
1. Keep my auto-formatting
2. Format additional files not relevant to the PR

If this is a problem, please see if you can revert my formatting! Sorry!